### PR TITLE
Update datatable validation

### DIFF
--- a/src/Vuetify/Update_validation_datatable.jl
+++ b/src/Vuetify/Update_validation_datatable.jl
@@ -42,6 +42,15 @@ UPDATE_VALIDATION["v-data-table"]=(x)->begin
             x.attrs["items"]=arr
             if !(haskey(x.attrs,"headers"))
                 x.attrs["headers"]=[Dict{String,Any}("value"=>trf_col(n),"text"=>n,"value_orig"=>n) for n in string.(names(df))]
+            else
+                @assert all(y->"value" in keys(y), x.attrs["headers"]) "Headers declared without value key"
+                for (i,header) in enumerate(x.attrs["headers"])
+                    val = header["value"]
+                    text = get(header, "text", val)
+                    x.attrs["headers"][i]["text"] = text
+                    x.attrs["headers"][i]["value"] = trf_col(val)
+                    x.attrs["headers"][i]["value_orig"] = val
+                end
             end
 
             ### Default Formatting


### PR DESCRIPTION
Support for custom headers as an array of `dicts` that describe header columns.
This would allow the passing of properties to each column, as well as separating a column's UI/display name from it's internal value(s) (linked to the `items` object) with which developers should operate upon. 

Example
```julia
@el(tab,
   "v-data-table",
    items=DataFrame(teste=[1,2,3], linha=["A","B","C"]),
    headers=[
        Dict("value"=>"teste", "text"=>"TesT"), 
        Dict("value"=>"linha", "text"=>"Line")],
    cols=6, 
    col_template=Dict("teste"=>html("v-chip", "abc-{{item.teste}}", Dict())),
    filter=Dict("linha"=>"=="))

@el(ftab, "v-text-field", change="filter_dt(tab, 'linha', ftab.value)")
```

Current solution for this would be similar to:
```julia
tab.attrs["headers"] = [Dict(x...,"text"=>"Column Name") for x in tab.attrs["headers"]]
```