### PR TITLE
Update Promise

### DIFF
--- a/src/Core/Events.jl
+++ b/src/Core/Events.jl
@@ -88,7 +88,8 @@ xhr_script = """function(contents, url=window.location.pathname, method="POST", 
                 } else {
                     reject({
                         status: request.status,
-                        statusText: request.statusText
+                        statusText: request.statusText,
+			responseText: request.responseText
                     });
             }};
      request.open(method, url, async);


### PR DESCRIPTION
Add responseText to `reject` handler, because servers' response messages are currently not available inside the `catch` block when a response status is not between 200 and 300