### PR TITLE
Remove v-btn `text` prop mapping to `content`

### DIFF
--- a/src/Vuetify/Update_validation.jl
+++ b/src/Vuetify/Update_validation.jl
@@ -70,7 +70,6 @@ UPDATE_VALIDATION["v-btn"]=(x)->begin
 
     ## attr alias of content
     haskey(x.attrs,"value") ? (x.attrs["content"]=x.attrs["value"];delete!(x.attrs,"value")) : nothing
-    haskey(x.attrs,"text") ? (x.attrs["content"]=x.attrs["text"];delete!(x.attrs,"text")) : nothing
 
     x.value_attr=nothing
 end


### PR DESCRIPTION
The `text` prop on a v-btn should define whether the buttons' background is transparent, as per https://vuetifyjs.com/en/api/v-btn/#props 
`text     boolean       false        Makes the background transparent.`
Current behaviour is assuming `text` as a replacement for props `value` and `content`