### PR TITLE
Enable usage of dividers inside v-list

### DIFF
--- a/docs/examples.jl
+++ b/docs/examples.jl
@@ -67,7 +67,7 @@ df[!,:Action]=df[!,:Text]
 page([[[st,d1],spacer(),[sel,d2],spacer(),[spacer(rows=4),d3,alert]]])
 """,
 "Navigation and Bar"=>"""
-items=[Dict("icon"=>"mdi-apple","title"=>"Apple","href"=>"https://www.apple.com"),Dict("icon"=>"mdi-cart-outline","title"=>"Shopping","href"=>"https://www.amazon.com")]
+items=[Dict("icon"=>"mdi-apple","title"=>"Apple","href"=>"https://www.apple.com"),Dict("divider" => true), Dict("icon"=>"mdi-cart-outline","title"=>"Shopping","href"=>"https://www.amazon.com")]
 @el(navel,"v-navigation-drawer",expand-on-hover=false,items=items)
 @el(homeb,"v-btn",icon=true,value="<v-icon>mdi-home</v-icon>",click="open('/home')")
 @el(searchb,"v-btn",icon=true,value="<v-icon>mdi-magnify</v-icon>",click="open('https://google.com')")

--- a/src/Vuetify/Update_validation.jl
+++ b/src/Vuetify/Update_validation.jl
@@ -81,6 +81,16 @@ fn=(x)->begin
     x.cols==nothing ? x.cols=3 : nothing
 end)
 
+UPDATE_VALIDATION["v-range-slider"]=(
+doc="""Simple Element, value attribute is value, return is an array of low and high value. Important attributes are min and max for minimum and maximum values, thumb-label will show the selected value if true or always for persintent.<br>
+    <code>
+    @el(slid,"v-range-slider",value=[10,20],min=0,max=50,thumb-label="always",thumb-color="red")
+    </code>
+    """,
+fn=(x)->begin
+    x.cols==nothing ? x.cols=3 : nothing
+end)
+
 UPDATE_VALIDATION["v-date-picker"]=(
 doc="""Simple Element, value attribute is value. Is invoked when v-text-field element has type date!. Can be used without v-text-field<br>
     <code>

--- a/src/Vuetify/Update_validation.jl
+++ b/src/Vuetify/Update_validation.jl
@@ -217,7 +217,7 @@ fn=(x)->begin
     x.cols==nothing ? x.cols=1 : nothing
 end)
 
-VueJS.UPDATE_VALIDATION["v-list"]=(
+UPDATE_VALIDATION["v-list"]=(
 doc="",
 value_attr="items",
 fn=(x)->begin


### PR DESCRIPTION
**Example of a list of v-navigation-drawer items:**
```julia
items = [
    Dict("icon" => "mdi-sitemap",         "title" => "Tree",   "href" => "/tree"),
    Dict("divider" => true)
    Dict("icon" => "mdi-cube-outline", "title" => "Cube",  "href" => "/cube")
]
```