### PR TITLE
Page instance globals, update material design icons version, VueHolder floating columns, v-snackbar

### DIFF
--- a/src/Core/Base.jl
+++ b/src/Core/Base.jl
@@ -10,7 +10,7 @@ DEPENDENCIES=[
                 WebDependency("https://cdnjs.cloudflare.com/ajax/libs/vuetify/2.4.9/vuetify.min.js","2.4.9","js",Dict(),"","",""),
                 WebDependency("https://cdnjs.cloudflare.com/ajax/libs/vuetify/2.4.9/vuetify.min.css","2.4.9","css",Dict(),"[v-cloak] {display: none}","",""),
                 WebDependency("https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900","1.0","css",Dict(),"","",""),
-                WebDependency("https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css","1.0","css",Dict(),"","",""),
+                WebDependency("https://cdn.jsdelivr.net/npm/@mdi/font@5.x/css/materialdesignicons.min.css","1.0","css",Dict(),"","",""),
                 
                 WebDependency("https://s3.eu-central-1.amazonaws.com/antonio.loureiro/JS/vue2editor.umd.min.js","2.6.6","js",Dict("VueEditor"=>"vue2editor.components.VueEditor"),".ql-container {height:auto !important} .ql-editor {height:auto !important}","",""),
                 WebDependency("https://s3.eu-central-1.amazonaws.com/antonio.loureiro/JS/vue2editor.umd.min.js.map","2.6.6","js",Dict(),"","",""),

--- a/src/Core/Page.jl
+++ b/src/Core/Page.jl
@@ -13,8 +13,9 @@ mutable struct Page
     components::Dict{String,Any}
     scripts::Vector{String}
     cookiejar::Dict{String, Any}
+    globals::Dict{String, Any}
 end
-Page(deps, comps, scripts) = return Page(deps, comps, scripts, Dict{String, Any}())
+Page(deps, comps, scripts) = return Page(deps, comps, scripts, Dict{String, Any}(), Dict{String, Any}())
 
 """
 Build HTML page, inclunding <head>, <body>, <scripts> and vuetify's initialization
@@ -75,6 +76,7 @@ function page(
     class=Dict{String,Any}(),
     scripts=[],
     cookies=Dict{String,Any}(),
+    globals = Dict{String, Any}(),
     navigation::Union{VueElement,Nothing}=nothing,
     bar::Union{VueHolder,Nothing}=nothing,
     sysbar::Union{VueElement, Nothing}=nothing,
@@ -85,13 +87,14 @@ function page(
     
     cont=VueStruct("app",garr,data=data,binds=binds,methods=methods,asynccomputed=asynccomputed,computed=computed,watch=watch,style=style,class=class;kwargs...)
     
-    return page(cont, navigation=navigation, bar=bar, sysbar=sysbar, footer=footer, bottom=bottom, scripts=scripts,cookies=cookies)
+    return page(cont, navigation=navigation, bar=bar, sysbar=sysbar, footer=footer, bottom=bottom, scripts=scripts,cookies=cookies, globals = globals)
 end
 
 function page(
         cont::VueStruct;
         scripts=[],
         cookies=Dict{String,Any}(),
+	globals = Dict{String, Any}(),
         sysbar::Union{VueElement, Nothing}=nothing,
         bar::Union{VueHolder,Nothing}=nothing,
         navigation::Union{VueElement,Nothing}=nothing,
@@ -111,7 +114,8 @@ function page(
             DEPENDENCIES,
             components,
             scripts,
-            cookies)
+            cookies,
+	    globals)
 
     return page_inst
 end

--- a/src/Core/VueHolder.jl
+++ b/src/Core/VueHolder.jl
@@ -6,7 +6,7 @@ mutable struct VueHolder
     cols::Union{Nothing,Float64}
     render_func::Union{Nothing,Function}
     
-    function VueHolder(tag::String,attrs::Dict,elements::Array,cols::Union{Nothing,Int64},render_func::Union{Nothing,Function})
+    function VueHolder(tag::String,attrs::Dict,elements::Array,cols::Union{Nothing,Real},render_func::Union{Nothing,Function})
         vueh=new(tag,attrs,elements,cols,render_func)
         
         if haskey(UPDATE_VALIDATION, tag)

--- a/src/Vuetify/Page.jl
+++ b/src/Vuetify/Page.jl
@@ -29,7 +29,7 @@ function htmlstring(page_inst::Page)
     components_dom=[]
     app_state=Dict{String,Any}()
     ## initialize globals
-    app_state["globals"]=Dict()
+    app_state["globals"]=page_inst.globals
 
     ## Other components
     for (k,v) in page_inst.components

--- a/src/Vuetify/Update_validation.jl
+++ b/src/Vuetify/Update_validation.jl
@@ -497,3 +497,17 @@ fn=(x)->begin
             
 end)
 
+VueJS.UPDATE_VALIDATION["v-progress-linear"]=(
+doc="""The <code> v-progress-linear </code> component is used to convey data visually to users. It's a practical way to show users that a loading or importing process is being executed at the moment.(see examples <a href="https://vuetifyjs.com/en/components/progress-linear/">here</a>)
+Default v-progress-linear; By default it has width corresponding to the size of its container, is indeterminate and is hidden (inactive).
+<code> @el(loading, "v-progress-linear")  </code>
+""",
+fn=(x)->begin
+        x.cols == nothing ? x.cols = 12 : nothing
+        
+        ## Basic Defaults
+        haskey(x.attrs, "indeterminate") ? nothing  : x.attrs["indeterminate"] = true
+        haskey(x.attrs, "active")   ? nothing : x.attrs["active"]  = false
+        haskey(x.attrs, "color")   ? nothing  : x.attrs["color"]   = "secondary"
+        haskey(x.attrs, "style")   ? nothing  : x.attrs["style"]   = Dict("margin" => "-12px", "width" => "auto")
+end)

--- a/src/Vuetify/Update_validation_datatable.jl
+++ b/src/Vuetify/Update_validation_datatable.jl
@@ -27,7 +27,7 @@ fn=(x)->begin
     col_pref="col_"
     trf_col=x->startswith(string(x),col_pref) ? string(x) : col_pref*VueJS.vue_escape(string(x))
     trf_dom=x->begin
-    x.attrs=Dict(k=>VueJS.vue_escape(v) for (k,v) in x.attrs)
+    x.attrs=Dict(k=> k == "click" ? v : VueJS.vue_escape(v) for (k,v) in x.attrs)
     x.value=x.value isa String ? VueJS.vue_escape(x.value) : x.value
     end
     


### PR DESCRIPTION
Globals feature of the page instance discussed on issue #82 cc8c3e3977560bb0f5c18ab9600a2f34a3c18029
Update material design icons version to 5.x,  db674856448e68424d790e90273d80163e397100
VueHolder constructor only accepted Int64 now it accepts a Real, enabling floating point and integer columns. 300487a126118eddef56988ff21d1d2a4eefe88d
Enabling camel case function names inside a click event instead of forcing lowercase with vue_escape. 1b0bb587bb560523bf917fb2481a21c97f77417e
Implementation of Vuetify Component v-snackbar #84  4bede2bc6d75322c93057e3e4699b0901c6fd5d4