### PR TITLE
JS naming inside v-data-tables. Fixed docs example.

### DIFF
--- a/docs/examples/basic_datatables.jl
+++ b/docs/examples/basic_datatables.jl
@@ -11,7 +11,7 @@ df[!,:Value]=rand(10).*10000 .-5000
 
 df[!,:Action]=df[!,:Text]
 @el(alert,"v-alert",type="success",text=true,cols=3)
-@el(btn,"v-btn",content="{{item.Text}}",binds=Dict("color"=>"item.Value<0 ? 'red' : 'blue'"),click="alert.content=item.Text;alert.value=true")
+@el(btn,"v-btn",content="{{item.Text}}",binds=Dict("color"=>"item.Value<0 ? 'red' : 'blue'"),click="alert.content=item.text;alert.value=true")
 @el(d3,"v-data-table",items=df,col_template=Dict("Action"=>btn),cols=3)
 
 page([[[st,d1],spacer(),[sel,d2],spacer(),[spacer(rows=4),d3,alert]]])

--- a/src/Vuetify/Update_validation_datatable.jl
+++ b/src/Vuetify/Update_validation_datatable.jl
@@ -27,8 +27,9 @@ fn=(x)->begin
     col_pref="col_"
     trf_col=x->startswith(string(x),col_pref) ? string(x) : col_pref*VueJS.vue_escape(string(x))
     trf_dom=x->begin
-    x.attrs=Dict(k=>VueJS.vue_escape(v) for (k,v) in x.attrs)
-    x.value=x.value isa String ? VueJS.vue_escape(x.value) : x.value
+        known_events_hooks = vcat(KNOWN_JS_EVENTS, KNOWN_HOOKS)
+        x.attrs = Dict(k => k in  known_events_hooks ? v : VueJS.vue_escape(v) for (k,v) in x.attrs)
+        x.value = x.value isa String ? VueJS.vue_escape(x.value) : x.value
     end
     
     haskey(x.attrs,"item-key") ? x.attrs["item-key"]=trf_col(x.attrs["item-key"]) : nothing


### PR DESCRIPTION
Adds non-restrictive in JS naming (works with any type of function names).
Fixed bug in basic-datatables docs. Tested docs code locally.