### PR TITLE
Include scripts as methods

### DIFF
--- a/src/Vuetify/Page.jl
+++ b/src/Vuetify/Page.jl
@@ -1,4 +1,4 @@
-#=const=# SFC_LOADER = read(joinpath(@__DIR__, "Page_SFC.js"), String)
+const SFC_LOADER = read(joinpath(@__DIR__, "Page_SFC.js"), String)
 function htmlstring(page_inst::VueJS.Page)
     includes=[]
     css_deps=[]
@@ -21,10 +21,6 @@ function htmlstring(page_inst::VueJS.Page)
 
     push!(head_items, html("style", join(css_deps," ")))
     head_dom = html("head", head_items, Dict())
-
-    # Prepare SCRIPTS
-    scripts = deepcopy(page_inst.scripts)
-    push!(scripts, "const vuetify = Vuetify.createVuetify()")
 
     components_dom=[]
 
@@ -60,6 +56,8 @@ function htmlstring(page_inst::VueJS.Page)
         push!(scripts, sfc_loader)
 
     else
+        # Prepare SCRIPTS
+        scripts = ["const vuetify = Vuetify.createVuetify()"]
 
         # Add components to scripts
         components = Dict{String,String}()
@@ -75,7 +73,7 @@ function htmlstring(page_inst::VueJS.Page)
             if k=="v-main"
                 ## component script
                 VueJS.update_data!(v,v.data)
-                VueJS.update_events!(v)
+                VueJS.update_events!(v, page_inst.scripts)
                 merge!(app_state,v.def_data)
                 
                 comp_script=[]

--- a/src/Vuetify/Page.jl
+++ b/src/Vuetify/Page.jl
@@ -22,7 +22,8 @@ function htmlstring(page_inst::VueJS.Page)
     push!(head_items, html("style", join(css_deps," ")))
     head_dom = html("head", head_items, Dict())
 
-    components_dom=[]
+    scripts         = []
+    components_dom  = []
 
     is_sfc = haskey(page_inst.components, "_placeholder") && page_inst.components["_placeholder"] isa VueSFC
     if is_sfc
@@ -56,8 +57,7 @@ function htmlstring(page_inst::VueJS.Page)
         push!(scripts, sfc_loader)
 
     else
-        # Prepare SCRIPTS
-        scripts = ["const vuetify = Vuetify.createVuetify()"]
+        push!(scripts, "const vuetify = Vuetify.createVuetify()")
 
         # Add components to scripts
         components = Dict{String,String}()

--- a/src/Vuetify/Page_SFC.js
+++ b/src/Vuetify/Page_SFC.js
@@ -34,6 +34,9 @@ const router = VueRouter.createRouter({
 // Load Vue SFC Loader
 const { loadModule } = window['vue3-sfc-loader'];
 
+// Instantiate Vuetify
+const vuetify = Vuetify.createVuetify()
+
 // Instantiate app
 const app = Vue.createApp({
     template: `<__SFC_PLACEHOLDER__ __SFC_PROPS__/>`,
@@ -42,4 +45,5 @@ const app = Vue.createApp({
     }
 });
 app.use(router);
+app.use(vuetify);
 router.isReady().then(() => app.mount('#app'));


### PR DESCRIPTION
## Description
1. Include JS code included in the page (`scripts` kwarg) as app methods (view example bellow)
2. Instantiate Vuetify and add it to the app.

## Example
```julia
function my_page(req::HTTP.Request) :: HTTP.Messages.Response
    @el(r1,"v-text-field",value="R1 Value",label="R1",cols=4)

    @el(bt_bt1,"v-btn",content="btn1",click="batata('BATATA')");
    @el(bt_bt2,"v-btn",content="btn2",click="batatinha1()",variant="outlined", block=true);
    @el(bt_bt3,"v-btn",content="btn3",click="batatinha2('BATATATINHA')",variant="outlined", block=true);

    return VueJS.response(page([r1,[bt_bt1,bt_bt2,bt_bt3]],
        methods = Dict("batata"=>"function(x){alert(this.r1.value);this.r1.value=x}"),
        scripts = ["""
            batatinha1: function(){alert(this.r1.value);this.r1.value=null},
            batatinha2: function(x){alert(app.globals.my_global);this.r1.value=x},
        """],
        globals = Dict(
            "my_global" => "hello"
        )
    ))
end
``